### PR TITLE
gr.Files sets unsupported type parameter input

### DIFF
--- a/scripts/upgraded_depth_anything_v2.py
+++ b/scripts/upgraded_depth_anything_v2.py
@@ -277,7 +277,7 @@ def on_ui_tabs():
             with gr.Row():
                 model_encoder_image_batch = gr.Dropdown(label="Select Model Encoder:", choices=encoders, value='vitl')            
             with gr.Row():
-                input_images = gr.Files(label="Upload Images", type="file", elem_id="img-display-input")
+                input_images = gr.Files(label="Upload Images", type="filepath", elem_id="img-display-input")
             with gr.Row():
                 with gr.Column(scale=8):
                     colour_map_dropdown_batch = gr.Dropdown(label="Select Colour Map Method:", choices=colour_map_methods, value='Spectral')            
@@ -329,7 +329,7 @@ def on_ui_tabs():
             with gr.Row():
                 model_encoder_video_batch = gr.Dropdown(label="Select Model Encoder:", choices=encoders, value='vitl')
             with gr.Row():
-                input_videos = gr.Files(label="Input Videos", type="file", elem_id='img-display-input')
+                input_videos = gr.Files(label="Input Videos", type="filepath", elem_id='img-display-input')
             with gr.Row():
                 with gr.Column(scale=5):
                     colour_map_dropdown_video_batch = gr.Dropdown(label="Select Colour Map Method:", choices=colour_map_methods, value='Spectral')


### PR DESCRIPTION
Error:
```
D:\Program Files\diffusion\webui_forge_cu121_torch21\webui\extensions\sd-webui-udav2\scripts\upgraded_depth_anything_v2.py:256: GradioDeprecationWarning: unexpected argument for Image: display_fn
  input_image = gr.Image(label="Input Image", type='filepath', elem_id='img-display-input', height=794, display_fn=lambda x: x)
D:\Program Files\diffusion\webui_forge_cu121_torch21\webui\extensions\sd-webui-udav2\scripts\upgraded_depth_anything_v2.py:257: GradioDeprecationWarning: unexpected argument for Image: display_fn
  depth_image_slider = gr.Image(label="Colourized Depth Map View", elem_id='img-display-output', height=794, display_fn=lambda x: x)
D:\Program Files\diffusion\webui_forge_cu121_torch21\webui\extensions\sd-webui-udav2\scripts\upgraded_depth_anything_v2.py:258: GradioDeprecationWarning: unexpected argument for Image: display_fn
  grey_depth_file_single = gr.Image(label="Greyscale Depth Map View", elem_id='img-display-output', height=794, display_fn=lambda x: x)
D:\Program Files\diffusion\webui_forge_cu121_torch21\webui\extensions\sd-webui-udav2\scripts\upgraded_depth_anything_v2.py:264: GradioDeprecationWarning: unexpected argument for Button: height
  submit_single = gr.Button(value="Compute Depth for Single Image", variant="primary", height=26)
*** Error executing callback ui_tabs_callback for D:\Program Files\diffusion\webui_forge_cu121_torch21\webui\extensions\sd-webui-udav2\scripts\upgraded_depth_anything_v2.py
    Traceback (most recent call last):
      File "D:\Program Files\diffusion\webui_forge_cu121_torch21\webui\modules\script_callbacks.py", line 283, in ui_tabs_callback
        res += c.callback() or []
      File "D:\Program Files\diffusion\webui_forge_cu121_torch21\webui\extensions\sd-webui-udav2\scripts\upgraded_depth_anything_v2.py", line 280, in on_ui_tabs
        input_images = gr.Files(label="Upload Images", type="file", elem_id="img-display-input")
      File "D:\Program Files\diffusion\webui_forge_cu121_torch21\system\python\lib\site-packages\gradio\component_meta.py", line 163, in wrapper
        return fn(self, **kwargs)
      File "D:\Program Files\diffusion\webui_forge_cu121_torch21\system\python\lib\site-packages\gradio\templates.py", line 513, in __init__
        super().__init__(
      File "D:\Program Files\diffusion\webui_forge_cu121_torch21\webui\modules\gradio_extensions.py", line 147, in __repaired_init__
        original(self, *args, **fixed_kwargs)
      File "D:\Program Files\diffusion\webui_forge_cu121_torch21\system\python\lib\site-packages\gradio\component_meta.py", line 163, in wrapper
        return fn(self, **kwargs)
      File "D:\Program Files\diffusion\webui_forge_cu121_torch21\system\python\lib\site-packages\gradio\components\file.py", line 98, in __init__
        raise ValueError(
    ValueError: Invalid value for parameter `type`: file. Please choose from one of: ['filepath', 'binary']
```

Gradio Version: 4.40.0
Forge Version: [f2.0.1v1.10.1-previous-581-ge4ad1140](https://github.com/lllyasviel/stable-diffusion-webui-forge/commit/e4ad1140c8c8344477345f2b7a6ca973f682fb31)
Python Version: python: 3.10.6 

Purpose: Changes the gr.Files() input parameter from "file" to "filepath", as "file" is not an accepted value. This error will prevent the udav2 **forge** extension from initializing the UI tab.